### PR TITLE
feat: update specs and documentation

### DIFF
--- a/.vuepress.config.ts
+++ b/.vuepress.config.ts
@@ -20,6 +20,9 @@ export default defineUserConfig({
     })
   ],
   markdown: {
+    code: {
+        lineNumbers: false
+    },
     linkify: true
   },
   theme: defaultTheme({

--- a/components/dnslink-result.vue
+++ b/components/dnslink-result.vue
@@ -19,7 +19,7 @@
         <thead>
           <tr>
             <td>namespace</td>
-            <td style="width: 100%">indentifier</td>
+            <td style="width: 100%">identifier</td>
             <td>ttl</td>
           </tr>
         </thead>

--- a/docs/README.md
+++ b/docs/README.md
@@ -127,18 +127,14 @@ example.com.		118	IN	TXT	"ALIAS for http-gateway.example.net"
 [name-registrar]: https://en.wikipedia.org/wiki/Domain_name_registrar
 [DNS]: https://en.wikipedia.org/wiki/Domain_Name_System
 [TXT]: https://en.wikipedia.org/wiki/TXT_record
-[dweb]: https://en.wikipedia.org/wiki/Decentralized_web
 [domain]: https://en.wikipedia.org/wiki/Domain_name
 [js]: https://npmjs.com/package/@dnslink/js
-[ASCII]: https://en.wikipedia.org/wiki/ASCII
 [go]: https://github.com/dnslink-std/go/releases
 [js-cli]: https://github.com/dnslink-std/js#command-line
 [go-cli]: https://github.com/dnslink-std/go#command-line
 [ipfs]: https://ipfs.io
 [hyper]: https://hypercore-protocol.org/protocol/#hyperdrive
 [multiaddr]: https://multiformats.io/multiaddr/
-[punycode]: https://en.wikipedia.org/wiki/Punycode
-[%-encoding]: https://en.wikipedia.org/wiki/Percent-encoding
 
 ## Tutorial
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -165,6 +165,7 @@ So the full domain name I'll set the record on is: `_dnslink.libp2p.io`.
 Let's set the link by creating a `TXT` record on the domain name. This is going to be specific to your DNS tooling. Unfortunately there is no standard cli tool or web service to set domain names :(. Every registrar and name server has its own web app, and API tooling. (yes, this is widely regarded as a poor state of affairs).
 
 Consider setting the record, via an imaginary dns cli tool:
+
 ```
 > my-dns-tool set --type=TXT --ttl=60 --domain=libp2p.io --name=_dnslink --value="dnslink=/ipfs/Qmc2o4ZNtbinEmRF9UGouBYTuiHbtCSShMFRbBY5ZiZDmU"
 _dnslink.libp2p.io TXT 60 dnslink=/ipfs/Qmc2o4ZNtbinEmRF9UGouBYTuiHbtCSShMFRbBY5ZiZDmU

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,7 +43,7 @@ There is also a `dnslink` CLI client provided with either [JavaScript][js] or [G
 
 ```sh
 > dnslink dnslink.dev
-/ipfs/QmaCveU7uyVKUSczmiCc85N7jtdZuBoKMrmcHbnnP26DCx    [ttl=120]
+/ipfs/QmaCveU7uyVKUSczmiCc85N7jtdZuBoKMrmcHbnnP26DCx
 ```
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4433,15 +4433,15 @@
       "dev": true
     },
     "node_modules/vite": {
-      "version": "2.9.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.9.tgz",
-      "integrity": "sha512-ffaam+NgHfbEmfw/Vuh6BHKKlI/XIAhxE5QSS7gFLIngxg171mg1P3a4LSRME0z2ZU1ScxoKzphkipcYwSD5Ew==",
+      "version": "2.9.15",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.15.tgz",
+      "integrity": "sha512-fzMt2jK4vQ3yK56te3Kqpkaeq9DkcZfBbzHwYpobasvgYmP2SoAr6Aic05CsB4CzCZbsDv4sujX3pkEGhLabVQ==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.14.27",
         "postcss": "^8.4.13",
         "resolve": "^1.22.0",
-        "rollup": "^2.59.0"
+        "rollup": ">=2.59.0 <2.78.0"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -7960,16 +7960,16 @@
       "dev": true
     },
     "vite": {
-      "version": "2.9.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.9.tgz",
-      "integrity": "sha512-ffaam+NgHfbEmfw/Vuh6BHKKlI/XIAhxE5QSS7gFLIngxg171mg1P3a4LSRME0z2ZU1ScxoKzphkipcYwSD5Ew==",
+      "version": "2.9.15",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.15.tgz",
+      "integrity": "sha512-fzMt2jK4vQ3yK56te3Kqpkaeq9DkcZfBbzHwYpobasvgYmP2SoAr6Aic05CsB4CzCZbsDv4sujX3pkEGhLabVQ==",
       "dev": true,
       "requires": {
         "esbuild": "^0.14.27",
         "fsevents": "~2.3.2",
         "postcss": "^8.4.13",
         "resolve": "^1.22.0",
-        "rollup": "^2.59.0"
+        "rollup": ">=2.59.0 <2.78.0"
       }
     },
     "vue": {


### PR DESCRIPTION
The new [test suite](https://github.com/dnslink-std/test) for DNSLink covers quite a few new topics.

_Note:_ The PR is set against the `next` branch. This is to prevent the immediate publication of the docs and allows us to publish the next version of DNSLink in one go as I will need to send a few more Pull Requests for updating other sections of the readme and links to the new libraries.