### PR TITLE
fix: add canonical link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,10 @@
+---
+head:
+  - - link
+    - rel: canonical
+      href: https://dnslink.dev/
+---
+
 ## Introduction
 
 DNSLink is a very simple protocol to link content and services directly from DNS.


### PR DESCRIPTION
This ensures SEO is applied correctly and results from .io and .org versions are merged under the canonical `dnslink.dev`